### PR TITLE
make to_svg public

### DIFF
--- a/src/chart.rs
+++ b/src/chart.rs
@@ -273,7 +273,7 @@ impl<'a> Chart<'a> {
     }
 
     /// Generate the SVG for the chart and its components.
-    fn to_svg(&self) -> Result<Group, String> {
+    pub fn to_svg(&self) -> Result<Group, String> {
         let mut group = Group::new()
             .set("class", "g-chart");
 


### PR DESCRIPTION
No need to have the `to_svg` function private, or is there?

https://github.com/askanium/rustplotlib/issues/1
