### PR TITLE
Bump svg to 0.13.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ repository = "https://github.com/askanium/rustplotlib"
 readme = "README.md"
 
 [dependencies]
-svg="0.7.1"
+svg = "0.13.1"
 format_num = "0.1.0"


### PR DESCRIPTION
ran cargo outdated and fixed svg's the minor version.

I testes this by running 

"examples/vertical_bar_chart.rs"

 as a binary linked to the modified library.

